### PR TITLE
[Add] node warning and modal routing to how-to-use page

### DIFF
--- a/frontend/src/components/CreateWebsite/PreviewSummary.tsx
+++ b/frontend/src/components/CreateWebsite/PreviewSummary.tsx
@@ -87,7 +87,7 @@ StatusMotionCard.displayName = "StatusMotionCard";
 import { Card, CardContent } from "@/components/ui/card";
 import { buildOutputSettingsType, advancedOptionsType } from "@/types/CreateWebstie/types";
 import { frameworks } from "@/constants/frameworks";
-import { Check, AlertCircle, Info, Sparkles, RefreshCw, X, GitBranch, Upload, Folder, Cpu, UploadCloud, Terminal, FolderOpen, Package, Shield, FileText, FolderInput } from "lucide-react";
+import { Check, AlertCircle, Info, Sparkles, RefreshCw, X, GitBranch, Upload, Folder, Cpu, UploadCloud, Terminal, FolderOpen, Package, Shield, FileText, FolderInput, AlertTriangle, MessageCircleQuestion } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { FormattedMessage } from 'react-intl';
 import { useIntl } from 'react-intl';
@@ -108,6 +108,7 @@ interface PreviewSummaryProps {
   selectedBranch?: string;
   setShowPreview: (showPreview: boolean) => void;
   projectPreview?: File;
+  failedToDeployCount: number;
   selectedRepoFile?: File | null;
   showBuildOutputSettings: boolean;
   deployingState: DeployingState;
@@ -278,6 +279,7 @@ export const PreviewSummary: React.FC<PreviewSummaryProps> = ({
   selectedRepoFile,
   showBuildOutputSettings,
   projectPreview,
+  failedToDeployCount,
   deployingResponse,
   buildingState,
 }) => {
@@ -396,6 +398,44 @@ export const PreviewSummary: React.FC<PreviewSummaryProps> = ({
               );
             }
             if (deployingState === DeployingState.Failed && deployingResponse) {
+              if (failedToDeployCount > 3) {
+                return (
+                  <>
+                    <StatusMotionCard
+                      key="warning"
+                      icon={<AlertTriangle className="w-6 h-6 text-yellow-500" />}
+                      color="yellow"
+                      title={<FormattedMessage id="createWebsite.deployFailed" defaultMessage="Deploy failed" />}
+                      description={<FormattedMessage id="createWebsite.deployFailedDescription" defaultMessage="Please try again or contact support for assistance." />}
+                      ariaLive="assertive"
+                    />
+                    <StatusMotionCard
+                      key="failed"
+                      icon={<X className="w-6 h-6 text-red-400" />}
+                      color="red"
+                      title={<FormattedMessage id="createWebsite.failedToDeploy" defaultMessage="Failed to deploy" />}
+                      description={<>
+                        <FormattedMessage id="createWebsite.failedToDeployDescription" defaultMessage="Please try again or contact support for assistance." />
+                        {deployingResponse.statusCode === 0 && deployingResponse.error && (
+                          <span className="block mt-1">{deployingResponse.error.error_message}</span>
+                        )}
+                      </>}
+                      ariaLive="assertive"
+                      className="bg-gradient-to-br from-red-900/30 to-red-800/20 border border-red-500/20"
+                    >
+                      <div className="mt-4 flex flex-col sm:flex-row gap-3">
+                        <Button
+                          onClick={() => setOpen(true)}
+                          className="group flex-1 items-center justify-center gap-2.5 bg-gradient-to-r from-red-500 to-amber-500 hover:from-red-600 hover:to-amber-600 text-white hover:text-white/90 px-6 py-2.5 rounded-xl font-semibold text-base transition-all duration-300 transform hover:scale-[1.02] focus:ring-2 focus:ring-offset-2 focus:ring-amber-400/50 shadow-lg shadow-red-500/20 hover:shadow-red-500/30"
+                        >
+                          <RefreshCw className="w-4 h-4 group-hover:animate-spin transition-transform duration-500 group-hover:rotate-180" />
+                          <FormattedMessage id="createWebsite.redeploy" defaultMessage="Try Again" />
+                        </Button>
+                      </div>
+                    </StatusMotionCard>
+                  </>
+                );
+              }
               return (
                 <StatusMotionCard
                   key="failed"
@@ -409,15 +449,17 @@ export const PreviewSummary: React.FC<PreviewSummaryProps> = ({
                     )}
                   </>}
                   ariaLive="assertive"
+                  className="bg-gradient-to-br from-red-900/30 to-red-800/20 border border-red-500/20"
                 >
-                  <Button
-                    className="mt-2 flex items-center gap-2 bg-gradient-to-r from-pink-500 via-red-500 to-yellow-500 hover:from-pink-600 hover:to-yellow-600 text-white px-6 py-2 rounded-lg font-semibold text-base shadow-lg shadow-red-100/30 dark:shadow-red-900/40 transition-all duration-300 hover:scale-105 focus:ring-2 focus:ring-offset-2 focus:ring-red-400"
-                    style={{ boxShadow: '0 2px 16px 0 rgba(255, 76, 76, 0.15)' }}
-                    onClick={() => setOpen(true)}
-                  >
-                    <RefreshCw className="w-5 h-5 mr-1 -ml-1 animate-spin-slow" />
-                    <FormattedMessage id="createWebsite.redeploy" defaultMessage="Redeploy" />
-                  </Button>
+                  <div className="mt-4 flex flex-col sm:flex-row gap-3">
+                    <Button
+                      onClick={() => setOpen(true)}
+                      className="group flex-1 items-center justify-center gap-2.5 bg-gradient-to-r from-red-500 to-amber-500 hover:from-red-600 hover:to-amber-600 text-white hover:text-white/90 px-6 py-2.5 rounded-xl font-semibold text-base transition-all duration-300 transform hover:scale-[1.02] focus:ring-2 focus:ring-offset-2 focus:ring-amber-400/50 shadow-lg shadow-red-500/20 hover:shadow-red-500/30"
+                    >
+                      <RefreshCw className="w-4 h-4 group-hover:animate-spin transition-transform duration-500 group-hover:rotate-180" />
+                      <FormattedMessage id="createWebsite.redeploy" defaultMessage="Try Again" />
+                    </Button>
+                  </div>
                 </StatusMotionCard>
               );
             }

--- a/frontend/src/components/CreateWebsiteDialog.tsx
+++ b/frontend/src/components/CreateWebsiteDialog.tsx
@@ -84,18 +84,18 @@ function CreateWebsiteDialog({
                   Login with Google
                 </span>
               </Button>
-            <div
-              className="w-full h-16 flex items-center justify-start space-x-3 bg-blue-600/60 shadow-inner p-4 mb-4 rounded-xl opacity-60 cursor-not-allowed select-none"
-            >
-              <img
-                src="https://upload.wikimedia.org/wikipedia/commons/6/6c/Facebook_Logo_2023.png"
-                className="w-10 h-10 rounded-full opacity-80"
-                alt="Facebook Logo"
-              />
-              <span className="text-lg font-bold tracking-wide text-white">
-                Coming Soon
-              </span>
-            </div>
+              <div
+                className="w-full h-16 flex items-center justify-start space-x-3 bg-blue-600/60 shadow-inner p-4 mb-4 rounded-xl opacity-60 cursor-not-allowed select-none"
+              >
+                <img
+                  src="https://upload.wikimedia.org/wikipedia/commons/6/6c/Facebook_Logo_2023.png"
+                  className="w-10 h-10 rounded-full opacity-80"
+                  alt="Facebook Logo"
+                />
+                <span className="text-lg font-bold tracking-wide text-white">
+                  Coming Soon
+                </span>
+              </div>
             </article>
           ) : (
             <article className="flex flex-col items-center justify-center">
@@ -110,7 +110,7 @@ function CreateWebsiteDialog({
                     variant="secondary"
                     className="h-12 bg-secondary-500 hover:bg-secondary-700 text-black cursor-pointer"
                     onClick={() => {
-                      window.open('/guide', '_blank')
+                      window.open('/how-to-use', '_blank')
                     }}
                   >
                     How to buy Sui NS

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -228,6 +228,9 @@ export default {
   'createWebsite.preview.ariaLabel': 'Preview not loading? Click for help',
   'createWebsite.preview.pathRecommendation': 'For best compatibility, we recommend using relative paths (starting with \'./\') for all local assets and links in your website.',
 
+  'createWebsite.deployFailed': 'Service temporarily unavailable',
+  'createWebsite.deployFailedDescription': 'The Walrus node is currently experiencing high traffic. Please try again later. We apologize for the inconvenience.',
+
   // Homepage
   'homepage.hero.title1': 'Launch Your Site In Few Clicks',
   'homepage.hero.title2': '',

--- a/frontend/src/i18n/translations/zh-CN.ts
+++ b/frontend/src/i18n/translations/zh-CN.ts
@@ -258,6 +258,9 @@ export default {
   'createWebsite.preview.ariaLabel': '预览未加载？点击获取帮助',
   'createWebsite.preview.pathRecommendation': '为了最佳兼容性，我们建议您使用相对路径（以 \'./\' 开始）为网站中的所有本地资产和链接。',
 
+  'createWebsite.deployFailed': '服务暂时不可用',
+  'createWebsite.deployFailedDescription': 'Walrus 节点当前正经历高流量。请稍后重试。我们对不便表示歉意。',
+
   // 导航和页面导航
   'howtouse.onThisPage': '在本页',
   'howtouse.backToTop': '返回顶部',

--- a/frontend/src/pages/CreateWebsite/index.tsx
+++ b/frontend/src/pages/CreateWebsite/index.tsx
@@ -114,6 +114,7 @@ export default function CreateWebsitePage() {
   const [open, setOpen] = useState(false)
 
   // State for deploying
+  const [failedToDeployCount, setFailedToDeployCount] = useState(0)
   const [isLoadingPreview, setIsLoadingPreview] = useState<boolean>(false)
   const [deployingState, setDeployingState] = useState<DeployingState>(
     DeployingState.None,
@@ -532,6 +533,7 @@ export default function CreateWebsitePage() {
     } catch (error) {
       console.error('Error:', error)
       setDeployingState(DeployingState.Failed)
+      setFailedToDeployCount((prev) => prev + 1)
       setDeployingResponse(error as ApiResponseError)
       throw error
     }
@@ -1126,6 +1128,7 @@ export default function CreateWebsitePage() {
                 projectShowcaseUrl={projectShowcaseUrl}
                 selectedBranch={selectedBranch}
                 projectPreview={projectPreview}
+                failedToDeployCount={failedToDeployCount}
               />
             </motion.div>
           </>


### PR DESCRIPTION
1. add node warning when redeploy more than 3 times
2. route to how-to-use page correctly when click how to buy a suins

![image](https://github.com/user-attachments/assets/d61b0ff7-0895-4dd8-bc90-a70e7bc2a029)
